### PR TITLE
Issue flush on request for SATA#0 virtual disk

### DIFF
--- a/stretch/virtualbox/Vagrantfile
+++ b/stretch/virtualbox/Vagrantfile
@@ -56,6 +56,7 @@ Vagrant.configure('2') do |config|
     vb.customize ['modifyvm', :id, '--uart2', 'off']
     vb.customize ['modifyvm', :id, '--uart3', 'off']
     vb.customize ['modifyvm', :id, '--uart4', 'off']
+    vb.customize ["setextradata", :id, "VBoxInternal/Devices/ahci/0/LUN#0/Config/IgnoreFlush", "0"]
 
     # only for dev and master
     vb.linked_clone = true

--- a/xenial/virtualbox/Vagrantfile
+++ b/xenial/virtualbox/Vagrantfile
@@ -53,6 +53,7 @@ Vagrant.configure('2') do |config|
     vb.customize ['modifyvm', :id, '--uart2', 'off']
     vb.customize ['modifyvm', :id, '--uart3', 'off']
     vb.customize ['modifyvm', :id, '--uart4', 'off']
+    vb.customize ["setextradata", :id, "VBoxInternal/Devices/ahci/0/LUN#0/Config/IgnoreFlush", "0"]
 
     # only for dev and master
     vb.linked_clone = true


### PR DESCRIPTION
Expect this commit to avoid the frequent BTRFS read only bug on Vagrant provisioned Virtualbox peers by issuing flush command on request for SATA#0 virtual disk, which is the only disk and used by the BTRFS file system in the template.